### PR TITLE
Fix missing humanize module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-tinypng",
   "description": "image optimization via tinypng service",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "https://github.com/marrone/grunt-tinypng",
   "author": "Mike M <mmarrone@pch.com>",
   "repository": {
@@ -44,7 +44,8 @@
     "grunt": "~0.4.2",
     "grunt-contrib-clean": "~0.4.1",
     "grunt-contrib-jshint": "~0.6.5",
-    "grunt-contrib-nodeunit": "~0.2.2"
+    "grunt-contrib-nodeunit": "~0.2.2",
+    "humanize": "~0.0.9"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.2.0",
     "grunt": "~0.4.2",
-    "humanize": "0.0.9"
+    "humanize": "~0.0.9"
   },
   "peerDependencies": {
     "grunt": "~0.4.2"


### PR DESCRIPTION
After updating to 0.3.0 version, grunt-tinypng starts to throw such error:

```
Loading "tinypng.js" tasks...ERROR
>> Error: Cannot find module 'humanize'
>>     at Function.Module._resolveFilename (module.js:338:15)
>>     at Function.Module._load (module.js:280:25)
>>     at Module.require (module.js:364:17)
>>     at require (module.js:380:17)
...
>> Error: Cannot find module 'humanize'
```

adding this module to `dependencies` should fix problem
