### PR TITLE
Added graceful-fs support

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.6.0",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.2.0",
+    "graceful-fs": "^3.0.6",
     "grunt": "~0.4.1",
+    "grunt-contrib-clean": "~0.4.0",
+    "grunt-contrib-jshint": "~0.6.0",
+    "grunt-contrib-nodeunit": "~0.2.0",
     "humanize": "~0.0.9",
     "multimeter": "~0.1.1",
     "promise": "~4.0.0"


### PR DESCRIPTION
When working with a big number of files, the ulimit can be hit and the plugin will run into EMFILE errors. I've added [Graceful FS](https://www.npmjs.com/package/graceful-fs) as a dependency, and updated the fs variable in the task to use this plugin. The other changes are removing whitespace from the end of lines.