### PR TITLE
Install `graceful-fs` as a dependency, fixes #19

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "graceful-fs": "^3.0.6",
     "grunt": "~0.4.1",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-jshint": "~0.6.0",
@@ -44,6 +43,7 @@
     "test": "test"
   },
   "dependencies": {
+    "graceful-fs": "^3.0.6",
     "grunt": "~0.4.1",
     "grunt-contrib-clean": "~0.4.1",
     "grunt-contrib-jshint": "~0.6.5",


### PR DESCRIPTION
since `graceful-fs` is main part of module we need to move it to `dependencies` section since `devDependencies` are not installed when you include this module as a part of your project